### PR TITLE
Fix file imports for linux

### DIFF
--- a/src/PythonResource.cpp
+++ b/src/PythonResource.cpp
@@ -6,13 +6,11 @@ bool PythonResource::Start()
 {
     alt::String mainFile = GetFullPath();
     
-    const char* path = resource->GetPath().CStr();
-    size_t newsize = strlen(path) + 1;
-    wchar_t * escapedPath = new wchar_t[newsize];
-    size_t convertedChars = 0;
-    mbstowcs_s(&convertedChars, escapedPath, newsize, path, _TRUNCATE);
+    std::string path = resource->GetPath().ToString();
+    std::wstring escapedPath;
+    escapedPath.assign(path.begin(), path.end());
 
-    PySys_SetPath(escapedPath);
+    PySys_SetPath(escapedPath.c_str());
 
     FILE* fp = fopen(mainFile.CStr(), "r");
     bool crashed = PyRun_SimpleFile(fp, mainFile.CStr());


### PR DESCRIPTION
The conversion of the path from string to wstring was only working on windows.
My bad. Heres the solution. Tested.