### PR TITLE
Add ToDegrees and ToRadians to Vector3 Class

### DIFF
--- a/src/classes/vector3.cpp
+++ b/src/classes/vector3.cpp
@@ -30,6 +30,9 @@ void RegisterVector3Class(const pybind11::module_& m) {
     pyClass.def("length", &Vector3::Length);
     pyClass.def("distance", &Vector3::Distance);
 
+    pyClass.def("toDegrees", &Vector3::ToDegrees);
+    pyClass.def("toRadians", &Vector3::ToRadians);
+
     pyClass.def("add", py::overload_cast<const double>(&Vector3::Add));
     pyClass.def("add", py::overload_cast<const py::list&>(&Vector3::Add));
     pyClass.def("add", py::overload_cast<const double, const double, const double>(&Vector3::Add));

--- a/src/classes/vector3.h
+++ b/src/classes/vector3.h
@@ -27,6 +27,16 @@ public:
         return "Vector3(" + std::to_string(x) + ", " + std::to_string(y) + ", " + std::to_string(z) + ")";
     }
 
+    Vector3 ToDegrees() const
+    {
+        return Vector3(x * (180 / alt::PI), y * (180 / alt::PI), z * (180 / alt::PI));
+    }
+
+    Vector3 ToRadians() const
+    {
+        return Vector3(x * (alt::PI / 180), y * (alt::PI / 180), z * (alt::PI / 180));
+    }
+
     double Length() const
     {
         return sqrt(x * x + y * y + z * z);

--- a/src/classes/vector3.h
+++ b/src/classes/vector3.h
@@ -29,7 +29,7 @@ public:
 
     Vector3 ToDegrees() const
     {
-        return Vector3(x * (180 / alt::PI), y * (180 / alt::PI), z * (180 / alt::PI));
+        return Vector3(std::round(x * (180 / alt::PI)), std::round(y * (180 / alt::PI)), std::round(z * (180 / alt::PI)));
     }
 
     Vector3 ToRadians() const


### PR DESCRIPTION
Added ToDegrees and ToRadians methods

### Example Code
```py
x = alt.Vector3(0.000000, 0.000000, 1.256637)
y = alt.Vector3(0.000000, 0.000000, 72)

alt.log(x.toDegrees())    # Vector3(0.000000, 0.000000, 72.000000)
alt.log(y.toRadians())    # Vector3(0.000000, 0.000000, 1.256637)
```