### PR TITLE
Add alt getters and setters

### DIFF
--- a/src/bindings/alt.h
+++ b/src/bindings/alt.h
@@ -8,5 +8,14 @@ unsigned int Hash(const std::string& strToHash) {
 
 void RegisterHelpersFunctions(py::module_ m)
 {
+    // Getters
+    m.attr("branch") = Core->GetBranch().ToString();
+    m.attr("defaultDimension") = alt::DEFAULT_DIMENSION;
+    m.attr("globalDimension") = alt::GLOBAL_DIMENSION;
+    m.attr("rootDir") = Core->GetRootDirectory().ToString();
+    m.attr("sdkVersion") = Core->SDK_VERSION;
+    m.attr("version") = Core->GetVersion().ToString();
+
+    // Methods
     m.def("hash", &Hash, "Hashes string");
 }

--- a/src/bindings/alt.h
+++ b/src/bindings/alt.h
@@ -10,6 +10,7 @@ void RegisterHelpersFunctions(py::module_ m)
 {
     // Getters
     m.attr("branch") = Core->GetBranch().ToString();
+    m.attr("debug") = Core->IsDebug();
     m.attr("defaultDimension") = alt::DEFAULT_DIMENSION;
     m.attr("globalDimension") = alt::GLOBAL_DIMENSION;
     m.attr("rootDir") = Core->GetRootDirectory().ToString();

--- a/src/bindings/alt.h
+++ b/src/bindings/alt.h
@@ -1,9 +1,48 @@
 #pragma once
 
 #include "main.h"
+#include "utils.h"
 
 unsigned int Hash(const std::string& strToHash) {
     return Core->Hash(strToHash);
+}
+
+uint32_t GetNetTime() {
+    return Core->GetNetTime();
+}
+
+void SetPassword(const std::string& password) {
+    Core->SetPassword(password);
+}
+
+py::object GetMeta(const std::string& key)
+{
+    return Utils::MValueToValue(Core->GetMetaData(key));
+}
+
+py::object GetSyncedMeta(const std::string& key)
+{
+    return Utils::MValueToValue(Core->GetSyncedMetaData(key));
+}
+
+bool HasMeta(const std::string& key)
+{
+    return Core->HasMetaData(key);
+}
+
+bool HasSyncedMeta(const std::string& key)
+{
+    return Core->HasSyncedMetaData(key);
+}
+
+void SetMeta(const std::string& key, const py::object& value)
+{
+    Core->SetMetaData(key, Utils::ValueToMValue(value));
+}
+
+void SetSyncedMeta(const std::string& key, const py::object& value)
+{
+    Core->SetSyncedMetaData(key, Utils::ValueToMValue(value));
 }
 
 void RegisterHelpersFunctions(py::module_ m)
@@ -19,4 +58,14 @@ void RegisterHelpersFunctions(py::module_ m)
 
     // Methods
     m.def("hash", &Hash, "Hashes string");
+    m.def("getNetTime", &GetNetTime, "Gets the amount of milliseconds since the server was started");
+    m.def("setPassword", &SetPassword, "Change the server password at runtime");
+
+    // Metadata
+    m.def("getMeta", &GetMeta, "Gets a value using the specified key");
+    m.def("getSyncedMeta", &GetSyncedMeta, "Gets a value using the specified key");
+    m.def("hasMeta", &HasMeta, "Determines whether contains the specified key");
+    m.def("hasSyncedMeta", &HasSyncedMeta, "Determines whether contains the specified key");
+    m.def("setMeta", &SetMeta, "Stores the given value with the specified key");
+    m.def("setSyncedMeta", &SetSyncedMeta, "Stores the given value with the specified key");
 }


### PR DESCRIPTION
Added a lot of alt methods (getters and setters). I was unable to implement resourceName, probably due a to a lack of knowledge

### Example Code
```py
alt.log(alt.debug)                          # True
alt.log(alt.defaultDimension)               # 0
alt.log(alt.branch)                         # dev
alt.log(alt.globalDimension)                # -2147483648
alt.log(alt.rootDir)                        # C:\Users\Zack\Documents\Scripting Projects\altv-server
alt.log(alt.sdkVersion)                     # 54
alt.log(alt.version)                        # 4.0-dev15
alt.log(alt.getNetTime())                   # 53
alt.log(alt.hash("hi"))                     # 1867409728

alt.setMeta("myMeta", 3)                    #
alt.log(alt.getMeta("myMeta"))              # 3

alt.setSyncedMeta("myMetaSynced", 3)        #
alt.log(alt.getSyncedMeta("myMetaSynced"))  # 3

alt.log(alt.hasMeta("myMeta"))              # True
alt.log(alt.hasSyncedMeta("myMetaSynced"))  # True
```